### PR TITLE
Address review feedback for CORS, auth, and scripts

### DIFF
--- a/.gitleaks.toml
+++ b/.gitleaks.toml
@@ -1,0 +1,10 @@
+title = "context-casial-xpress gitleaks config"
+
+[allowlist]
+  description = "Allow test Authorization headers"
+  paths = [
+    "test-smithery-compatibility.sh"
+  ]
+  regexes = [
+    "Authorization: Bearer wrong-key"
+  ]

--- a/MCP_CAPABILITIES_IMPLEMENTATION.md
+++ b/MCP_CAPABILITIES_IMPLEMENTATION.md
@@ -6,7 +6,7 @@ Successfully implemented all four MCP (Model Context Protocol) capabilities in t
 1. **Tools** ✅ - Already implemented, with orchestration-aware tools
 2. **Prompts** ✅ - Added orchestration and analysis prompts  
 3. **Resources** ✅ - Added context, history, consciousness state, and federation info
-4. **Sampling** ✅ - Advertised when `MOP_ENABLE_SAMPLING` is truthy so clients know to delegate
+4. **Sampling** ✅ - Advertised only when `MOP_ENABLE_SAMPLING` is truthy (hidden otherwise) so clients know to delegate
 
 ## Key Changes
 

--- a/SMITHERY_INTEGRATION.md
+++ b/SMITHERY_INTEGRATION.md
@@ -14,8 +14,9 @@
 - Added POST support for potential JSON-RPC requests
 
 ### 3. CORS Headers
-- **Allowed headers**: `Authorization`, `Mop-Api-Key`, `Content-Type`, and MCP session headers
-- **Exposed headers**: `mcp-session-id`, `mcp-protocol-version`, `x-session-id`
+- **Allowed headers**: `Authorization`, `Mop-Admin-Token`, `Content-Type`, and MCP session headers
+- Smithery caches should respect `Vary: Origin, Authorization, Mop-Admin-Token` to avoid credential mix-ups.
+- **Exposed headers**: `mcp-session-id`, `mcp-protocol-version`
 - **Credentials**: Enabled when `ALLOWED_ORIGINS` is a comma-delimited allow list; disabled automatically for `*`
 - **Methods**: GET, POST, OPTIONS
 

--- a/bench/sse_keep_alive.js
+++ b/bench/sse_keep_alive.js
@@ -9,6 +9,10 @@ const KEEP_ALIVE_WINDOW = Number(__ENV.MOP_SSE_WINDOW_MS || 5000);
 export const options = {
   vus: Number(__ENV.MOP_SSE_VUS || 5),
   iterations: Number(__ENV.MOP_SSE_ITERATIONS || 20),
+  thresholds: {
+    sse_failures: ['rate<0.05'],
+  },
+  discardResponseBodies: true,
 };
 
 const failures = new Rate('sse_failures');

--- a/bench/tools_call_rps.js
+++ b/bench/tools_call_rps.js
@@ -61,6 +61,7 @@ export default function () {
   const listRes = http.post(BASE_URL, listPayload, {
     headers: {
       'Content-Type': 'application/json',
+      Authorization: `Bearer ${API_KEY}`,
       'mcp-session-id': sessionId,
     },
   });

--- a/crates/casial-server/src/websocket.rs
+++ b/crates/casial-server/src/websocket.rs
@@ -348,16 +348,20 @@ impl WebSocketHandler {
             .and_then(|v| v.as_str())
             .ok_or_else(|| anyhow::anyhow!("Missing tool name"))?;
 
-        let args = params
+        let mut args = params
             .get("arguments")
             .cloned()
             .unwrap_or(serde_json::json!({}));
 
-        // Extract execution mode
-        let mode = args
+        // Extract execution mode (request-level)
+        let mode = params
             .get("mode")
             .and_then(|v| v.as_str())
             .unwrap_or("execute");
+
+        if let Some(obj) = args.as_object_mut() {
+            obj.remove("mode");
+        }
 
         info!(
             "🔧 Executing tool: {} with consciousness coordination (mode: {})",

--- a/docs/README.md
+++ b/docs/README.md
@@ -453,10 +453,16 @@ curl http://localhost:8000/metrics
 # Debug information
 curl http://localhost:8000/debug/substrate \
   -H "Mop-Admin-Token: ${MOP_ADMIN_TOKEN:-set-me}"
+curl http://localhost:8000/debug/substrate \
+  -H "Authorization: Bearer ${MOP_ADMIN_TOKEN:-set-me}"
 curl http://localhost:8000/debug/sessions \
   -H "Mop-Admin-Token: ${MOP_ADMIN_TOKEN:-set-me}"
+curl http://localhost:8000/debug/sessions \
+  -H "Authorization: Bearer ${MOP_ADMIN_TOKEN:-set-me}"
 curl http://localhost:8000/debug/perceptions \
   -H "Mop-Admin-Token: ${MOP_ADMIN_TOKEN:-set-me}"
+curl http://localhost:8000/debug/perceptions \
+  -H "Authorization: Bearer ${MOP_ADMIN_TOKEN:-set-me}"
 ```
 
 ## 📚 Examples & Tutorials

--- a/docs/deployment/smithery.md
+++ b/docs/deployment/smithery.md
@@ -35,13 +35,15 @@ Session configuration is passed by clients when connecting to your server via qu
 
 | Parameter | Type | Required | Description |
 |-----------|------|----------|-------------|
-| `apiKey` | string | Yes | Authentication key (DEMO KEY – public; override with `MOP_API_KEY`) |
+| `apiKey` | string | Yes* | Authentication key (DEMO KEY – public; override with `MOP_API_KEY`; Authorization header accepted as an alternative) |
 | `agent_role` | string | No | Agent role for context: researcher, analyst, monitor, watcher, orchestrator |
 | `consciousness_mode` | string | No | Consciousness level: full, partial, disabled (default: full) |
 | `max_context_size` | integer | No | Max context characters (1000-1000000, default: 100000) |
 | `mission` | string | No | Pre-configured mission: exa-orchestration, general, research, monitoring |
 | `shim_enabled` | boolean | No | Enable pitfall avoidance (default: true) |
 | `debug` | boolean | No | Enable debug logging (default: false) |
+
+> **Note:** `apiKey` remains required unless every request supplies an `Authorization: Bearer` header.
 
 ### Example Session Requests
 
@@ -212,7 +214,7 @@ Should show `"transport": ["streamable-http"]`
 ### Session Configuration Not Applied
 
 Check that session parameters are properly encoded in the URL:
-```
+```text
 ?agent_role=researcher&consciousness_mode=full
 ```
 

--- a/docs/integrations/exa-mcp.md
+++ b/docs/integrations/exa-mcp.md
@@ -34,6 +34,8 @@ casial-server start \
 }
 ```
 
+Clients should send the value of `config.apiKey` as an `Authorization: Bearer` header on every MCP request; the config field is purely a client-side convenience.
+
 When configuring clients programmatically, prefer environment variables and fall back to the demo key only for local testing:
 
 ```javascript
@@ -226,7 +228,7 @@ All augmentations are logged with:
       "args": ["path/to/casial-mcp-client.js"],
       "env": {
         "CASIAL_URL": "http://localhost:8080/mcp",
-        "CASIAL_API_KEY": "REPLACE_WITH_YOUR_API_KEY",
+        "MOP_API_KEY": "REPLACE_WITH_YOUR_API_KEY",
         "AGENT_ROLE": "researcher"
       }
     }

--- a/test_mop_curl_commands.sh
+++ b/test_mop_curl_commands.sh
@@ -1,11 +1,13 @@
 #!/bin/bash
+set -euo pipefail
 
 # Meta-Orchestration Protocol (MOP) cURL Test Commands
 
 API_KEY="${MOP_API_KEY:-DEMO_KEY_PUBLIC}"
+BASE_URL="${MOP_HTTP_BASE:-https://context-casial-xpress-production.up.railway.app}"
 
 echo "=== 1. Initialize Session ==="
-SESSION_ID=$(curl -X POST https://context-casial-xpress-production.up.railway.app/mcp \
+SESSION_ID=$(curl -X POST "${BASE_URL}/mcp" \
   -H "Content-Type: application/json" \
   -H "Accept: application/json, text/event-stream" \
   -H "Authorization: Bearer $API_KEY" \
@@ -23,11 +25,17 @@ SESSION_ID=$(curl -X POST https://context-casial-xpress-production.up.railway.ap
     "id": 1
   }' -s | jq -r '.result.sessionId')
 
+if [ -z "${SESSION_ID:-}" ] || [ "$SESSION_ID" = "null" ]; then
+  echo "Failed to initialize session"
+  exit 1
+fi
+
 echo "Session ID: $SESSION_ID"
 
 echo -e "\n=== 2. List Tools ==="
-curl -X POST https://context-casial-xpress-production.up.railway.app/mcp \
+curl -X POST "${BASE_URL}/mcp" \
   -H "Content-Type: application/json" \
+  -H "Authorization: Bearer $API_KEY" \
   -H "mcp-session-id: $SESSION_ID" \
   -d '{
     "jsonrpc": "2.0",
@@ -37,8 +45,9 @@ curl -X POST https://context-casial-xpress-production.up.railway.app/mcp \
   }' -s | jq '.result.tools[].name'
 
 echo -e "\n=== 3. List Prompts ==="
-curl -X POST https://context-casial-xpress-production.up.railway.app/mcp \
+curl -X POST "${BASE_URL}/mcp" \
   -H "Content-Type: application/json" \
+  -H "Authorization: Bearer $API_KEY" \
   -H "mcp-session-id: $SESSION_ID" \
   -d '{
     "jsonrpc": "2.0",
@@ -48,8 +57,9 @@ curl -X POST https://context-casial-xpress-production.up.railway.app/mcp \
   }' -s | jq '.result.prompts[].name'
 
 echo -e "\n=== 4. List Resources ==="
-curl -X POST https://context-casial-xpress-production.up.railway.app/mcp \
+curl -X POST "${BASE_URL}/mcp" \
   -H "Content-Type: application/json" \
+  -H "Authorization: Bearer $API_KEY" \
   -H "mcp-session-id: $SESSION_ID" \
   -d '{
     "jsonrpc": "2.0",
@@ -59,8 +69,9 @@ curl -X POST https://context-casial-xpress-production.up.railway.app/mcp \
   }' -s | jq '.result.resources[].name'
 
 echo -e "\n=== 5. Call Orchestrate Tool (Example) ==="
-curl -X POST https://context-casial-xpress-production.up.railway.app/mcp \
+curl -X POST "${BASE_URL}/mcp" \
   -H "Content-Type: application/json" \
+  -H "Authorization: Bearer $API_KEY" \
   -H "mcp-session-id: $SESSION_ID" \
   -d '{
     "jsonrpc": "2.0",
@@ -77,6 +88,7 @@ curl -X POST https://context-casial-xpress-production.up.railway.app/mcp \
   }' -s | jq '.'
 
 echo -e "\n=== 6. Terminate Session ==="
-curl -X DELETE https://context-casial-xpress-production.up.railway.app/mcp \
+curl -X DELETE "${BASE_URL}/mcp" \
+  -H "Authorization: Bearer $API_KEY" \
   -H "mcp-session-id: $SESSION_ID" \
   -i 2>&1 | grep "HTTP/1.1"


### PR DESCRIPTION
## Summary
- harden the HTTP MCP surface by letting CORS resolution return `None`, honoring it in manual header application, parsing `Authorization` case-insensitively, emitting keep-alive comments, surfacing tool output schemas, and hiding sampling metadata unless the flag is enabled
- refresh Smithery-facing tooling and docs to avoid query param secrets, prefer bearer headers, and document the updated auth/CORS behaviour while adding a gitleaks allowlist for the intentional test token
- align load-test scripts with the new auth requirements by always sending bearer headers and adding SSE health thresholds/discarded bodies

## Testing
- cargo fmt
- cargo test -p casial-server

------
https://chatgpt.com/codex/tasks/task_e_68d5abfae54c8328a3f856c504583961